### PR TITLE
add ghost recipe for cms and split existing grunt.rb into 3 parts

### DIFF
--- a/base.rb
+++ b/base.rb
@@ -150,6 +150,7 @@ def test_command cmd
 end
 
 set_default :recipe_base, "lib"
+set_default :config_sub_dir, ""
 
 #
 # DSL extensions. Some functions to extend current Capistrano DSL with

--- a/bower.rb
+++ b/bower.rb
@@ -1,0 +1,14 @@
+#
+# Install Bower
+#
+
+namespace :deploy do
+
+  namespace :bower do
+    task :install do
+      run "cd #{current_release}#{config_sub_dir}; git config url.\"https://\".insteadOf git:// ; bower --config.interactive=false install > /tmp/bower-install.log 2>&1"
+    end
+  end
+
+end
+after "bundle:install", "deploy:bower:install"

--- a/ghost.rb
+++ b/ghost.rb
@@ -1,0 +1,30 @@
+#
+# Deploy ghost contents
+#
+
+namespace :ghost do
+
+  desc <<-EOH
+
+Create symlink to the current release for ghost.
+
+EOH
+
+  task :create_symlink do
+    on_rollback do
+      if latest_release
+        run "#{try_sudo} rm -f #{ghost_content_path}/themes/coiney; #{try_sudo} ln -s #{latest_release}/themes/coiney #{ghost_content_path}/themes/coiney; true"
+      else
+        logger.important "ghost : no previous release to rollback to, rollback of symlink skipped"
+      end
+    end
+    run "#{try_sudo} rm -f #{ghost_content_path}/themes/coiney && #{try_sudo} ln -s #{current_release}/themes/coiney #{ghost_content_path}/themes/coiney"
+  end
+
+  task :restart do
+    run "#{try_sudo} /sbin/sv restart ghost"
+  end
+end
+
+after "deploy:finalize_update", "ghost:create_symlink"
+after "ghost:create_symlink", "ghost:restart"

--- a/grunt.rb
+++ b/grunt.rb
@@ -1,38 +1,14 @@
 #
-# Install NPM modules and Bower, Grunt build
+# Install Grunt build
 #
 
 namespace :deploy do
 
-  namespace :npm do
-
-    desc "Remove NPM caches in case npm intall fails"
-    task :fix do
-      run "cd ~#{user} && #{sudo} rm -rf tmp .npm "
-    end
-
-    task :install do
-      run "which npm > /dev/null || ( #{chef_solo_command} #{chef_solo_remote}/web.json )"
-      run "cd ~#{user} && mkdir -p tmp .npm && #{sudo} chown -R #{user}:#{user} tmp .npm "
-      run "cd #{shared_path} && mkdir -p node_modules"
-      run "cd #{current_release} && ln -nfs #{shared_path}/node_modules"
-      run "cd #{current_release}; npm install > /tmp/npm-install.log 2>&1 "
-    end
-  end
-
-  namespace :bower do
-    task :install do
-      run "cd #{current_release}; git config url.\"https://\".insteadOf git:// ; bower --config.interactive=false install > /tmp/bower-install.log 2>&1"
-    end
-  end
-
   namespace :grunt do
     task :build do
-      run "cd #{current_release}; bundle exec grunt build "; #> /tmp/grunt-build.log 2>&1"
+      run "cd #{current_release}#{config_sub_dir}; bundle exec grunt build "; #> /tmp/grunt-build.log 2>&1"
     end
   end
 
 end
-after "bundle:install", "deploy:npm:install"
-after "bundle:install", "deploy:bower:install"
 after "deploy:bower:install", "deploy:grunt:build"

--- a/npm.rb
+++ b/npm.rb
@@ -1,0 +1,24 @@
+#
+# Install NPM modules
+#
+
+namespace :deploy do
+
+  namespace :npm do
+
+    desc "Remove NPM caches in case npm intall fails"
+    task :fix do
+      run "cd ~#{user} && #{sudo} rm -rf tmp .npm "
+    end
+
+    task :install do
+      run "which npm > /dev/null || ( #{chef_solo_command} #{chef_solo_remote}/web.json )"
+      run "cd ~#{user} && mkdir -p tmp .npm && #{sudo} chown -R #{user}:#{user} tmp .npm "
+      run "cd #{shared_path} && mkdir -p node_modules"
+      run "cd #{current_release} && ln -nfs #{shared_path}/node_modules"
+      run "cd #{current_release}#{config_sub_dir}; npm install > /tmp/npm-install.log 2>&1 "
+    end
+  end
+
+end
+after "bundle:install", "deploy:npm:install"


### PR DESCRIPTION
This PR includes 3 things.
- 1. Split an existing grunt.rb into 3 parts named bower.rb, npm.rb and  grunt.rb.
- 2. Add a new variable config_sub_dir to search for manifest configs in sub-directories.
- 3. Add ghost.rb for capistrano to create symlink and restart ghost in ghost setup procedure.

@dmytro 
Please review.