### PR TITLE
add response time & http_x_forwarded_for to log_format in nginx.conf

### DIFF
--- a/templates/nginx.conf.erb
+++ b/templates/nginx.conf.erb
@@ -27,7 +27,12 @@ server {
   }
 <% end -%>
 
-  access_log "<%= nginx_access_log -%>";
+  log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                    '$status $body_bytes_sent "$http_referer" '
+                    '"$http_user_agent" "$http_x_forwarded_for"'
+                    '"$upstream_response_time"';
+
+  access_log "<%= nginx_access_log -%>" main;
   error_log  "<%= nginx_error_log -%>";
 
 location ^~ /assets/ {

--- a/templates/nginx.conf.erb
+++ b/templates/nginx.conf.erb
@@ -30,7 +30,7 @@ server {
   log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
                     '$status $body_bytes_sent "$http_referer" '
                     '"$http_user_agent" "$http_x_forwarded_for"'
-                    '"$upstream_response_time"';
+                    '"$request_time"';
 
   access_log "<%= nginx_access_log -%>" main;
   error_log  "<%= nginx_error_log -%>";


### PR DESCRIPTION
As per https://github.com/Coiney/capiche/issues/103,
I added the following elements to log_format in nginx.conf.
- upstream_response_time (shows how long nginx takes to process the request)
- http_x_forwarded_for (shows client IP)

@dmytro 
Please review.