### PR TITLE
Change the stage environment referer

### DIFF
--- a/notify_slack.rb
+++ b/notify_slack.rb
@@ -32,7 +32,7 @@ def _send_message(message, channel)
 end
 
 def _slack_channel
-  (fetch(:chef_environment) == "testing") ? "dev_test" : "#dev-deploy"
+  (fetch(:stage) == "localhost") ? "dev_test" : "#dev-deploy"
 end
 
 
@@ -50,7 +50,7 @@ namespace :slack do
         msg << "Application  : #{fetch(:application)}\n"
       end
       msg << "Branch/Tag   : #{fetch(:branch)}\n"
-      msg << "Environment  : #{fetch(:chef_environment)}\n"
+      msg << "Environment  : #{fetch(:stage)}\n"
       msg << "My commander : #{fetch(:user_name)}\n"
       msg << "\`\`\`\n"
 


### PR DESCRIPTION
Regarding PR : https://github.com/Coiney/capiche/pull/133,
- the notifier refers to parameter `stage` instead of `chef_environment` as you requested.
- the notifier shut up for the deployment to `localhost` (for private test).

@dmytro 
Please review.