### PR TITLE
Escape channel notification

### DIFF
--- a/notify_slack.rb
+++ b/notify_slack.rb
@@ -40,7 +40,7 @@ namespace :slack do
   namespace :deploy do
     task :start do
 
-      msg = "@channel:\n Hey guys, I just started deployment by order of my commander.\n"
+      msg = "<!channel>\n Hey guys, I just started deployment by order of my commander.\n"
       msg << "\`\`\`\n"
       if fetch(:only_infra, false)
         msg << "Application  : infrastructure}\n"


### PR DESCRIPTION
According to https://api.slack.com/docs/formatting,
Channel notification should be escaped like <!channel>.

@dmytro 
Please review.