### PR TITLE
add force option to make soft link in nginx conf

### DIFF
--- a/nginx.rb
+++ b/nginx.rb
@@ -88,7 +88,7 @@ DESC
     try_sudo "mkdir -p #{shared_path}/config"
     sudo "mkdir -p /etc/nginx/sites-enabled/"
     sudo "mv /tmp/nginx_site_conf /etc/nginx/sites-available/#{nginx_config_name}"
-    sudo "ln -s /etc/nginx/sites-available/#{nginx_config_name} /etc/nginx/sites-enabled/"
+    sudo "ln -sf /etc/nginx/sites-available/#{nginx_config_name} /etc/nginx/sites-enabled/"
     sudo "mv /tmp/nginx_conf /etc/nginx/nginx.conf"
     sudo "rm -f /etc/nginx/sites-enabled/default"
   end

--- a/nginx.rb
+++ b/nginx.rb
@@ -88,7 +88,7 @@ DESC
     try_sudo "mkdir -p #{shared_path}/config"
     sudo "mkdir -p /etc/nginx/sites-enabled/"
     sudo "mv /tmp/nginx_site_conf /etc/nginx/sites-available/#{nginx_config_name}"
-    sudo "ln -sf /etc/nginx/sites-available/#{nginx_config_name} /etc/nginx/sites-enabled/"
+    sudo "ln -nsf /etc/nginx/sites-available/#{nginx_config_name} /etc/nginx/sites-enabled/"
     sudo "mv /tmp/nginx_conf /etc/nginx/nginx.conf"
     sudo "rm -f /etc/nginx/sites-enabled/default"
   end


### PR DESCRIPTION
I found that we need force option to make a soft link to /etc/nginx/sites-enabled when the old file already exists.
@dmytro 
Please review.